### PR TITLE
Add support for Firefox (work in progress)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,18 +1,20 @@
 {
   "name": "Refgen",
   "version": "1.3.0",
-  "manifest_version": 3,
+  "manifest_version": 2,
   "description": "Generate referrer for current page.",
   "author": "Reorx <novoreorx@gmail.com>",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "refgen@reorx.com"
+    }
+  },
   "icons": {
     "16": "logo-947.png",
     "48": "logo-947.png",
     "128": "logo-947.png"
   },
-  "background": {
-    "service_worker": "background.js"
-  },
-  "action": {
+  "browser_action": {
     "default_popup": "popup.html"
   },
   "commands": {
@@ -24,9 +26,8 @@
     }
   },
   "permissions": [
-    "tabs",
     "activeTab",
-    "storage",
-    "scripting"
+	"tabs",
+    "storage"
   ]
 }

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title></title>
+  <title>refgen</title>
   <style>
     textarea {
       padding: 5px;


### PR DESCRIPTION
It runs on Firefox for now (dev edition 96.0b7), but `manifest.json` has been modified for Firefox only. Having separate `manifest.json`s for different browsers is necessary, and supposedly, also a `Makefile` or something similiar to package and upload to their respective extension stores.